### PR TITLE
Support generic attributes on class Model

### DIFF
--- a/source/model.ts
+++ b/source/model.ts
@@ -4,13 +4,13 @@ import Backbone = require('backbone');
 import $ = require('jquery');
 import _ = require('underscore');
 
-class Model extends Backbone.Model {
+class Model<TAttr extends {} = {}> extends Backbone.Model {
 
-    constructor(attributes, options?) {
+    constructor(attributes: TAttr, options?) {
         super(attributes, options);
     }
 
-    initialize (attributes, options) {
+    initialize (attributes: TAttr, options) {
 
         var defaultOptions = {
             virtualAttributes: []
@@ -39,11 +39,11 @@ class Model extends Backbone.Model {
 
     }
 
-    get (attribute) {
+    get <K extends keyof TAttr>(attribute: K): TAttr[K] {
 
-        if (typeof this[attribute] === 'function') {
+        if (typeof (<any>this)[attribute] === 'function') {
 
-            return this[attribute]();
+            return (<any>this)[attribute]();
 
         } else {
 
@@ -51,6 +51,10 @@ class Model extends Backbone.Model {
 
         }
 
+    }
+
+    set<K extends keyof TAttr>(attribute: K, value: TAttr[K]) {
+        return super.set(attribute);
     }
 
     toJSON () {


### PR DESCRIPTION
This PR introduces generic attributes on class `Model`, e.g:

```ts
interface IExample {
    a: number;
    b: string;
    c?: boolean;
}

// OK:
new Model<IExample>({
    a: 1,
    b: '2',
    c: true
});

// also OK:
new Model<IExample>({
    a: 1,
    b: '2'
});

// OK too:
let m: Model<IExample>;
// ...
m = new Model({ a: 1, b: '2' });

// Type Error:
new Model<IExample>({
    a: 'abc',
    b: '2'
});
```

The main benefit though is type safety for the `get` and `set` methods:

```ts
const m = new Model<IExample>({
    a: 1,
    b: '2',
    c: true
});

const a1: number = m.get('a'); // ok
const a2: string = m.get('a'); // type error

m.set('a', 1); // ok
m.set('a', '1'); // type error
```


FYI @MasGaNo 